### PR TITLE
Fix sitemap XML header

### DIFF
--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -25,8 +25,8 @@ function generateSitemap(): string {
   );
 
   return stripIndent`
-    <xml version="1.0" encoding="UTF-8">
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
       ${urls.map((url) => generateUrl(url)).join("\n")}
     </urlset>
     </xml>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in as much detail as you deem necessary -->

## Motivation and Context

The XML header for the sitemap was missing a `?`. I'm good at my job, I swear.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Text content in this PR was created by a human and not AI.
- [x] I have read the [contribution guidelines](/docs/CONTRIBUTING.md) and [code of conduct](/docs/CODE_OF_CONDUCT.md).
